### PR TITLE
feat(cms): S3 storage backend (PR D)

### DIFF
--- a/cms/app/config.py
+++ b/cms/app/config.py
@@ -13,6 +13,12 @@ class Settings(BaseSettings):
     media_root: str = "media"
     media_url: str = "/media/"
     media_originals_dir: str = "originals"
+    # S3 backend (used when MEDIA_STORAGE=s3)
+    aws_region: str = "us-west-2"
+    aws_s3_bucket: str = "housegallery-cms"
+    aws_access_key_id: str = ""
+    aws_secret_access_key: str = ""
+    s3_base_url: str = ""
 
 
 @lru_cache

--- a/cms/app/storage.py
+++ b/cms/app/storage.py
@@ -62,9 +62,54 @@ class LocalStorage(Storage):
         return self._path(rel_path).is_file()
 
 
+class S3Storage(Storage):
+    """Stores files in an AWS S3 bucket. Serves public URLs via the bucket.
+
+    Uses the CMS app's scoped IAM credentials (aws_access_key_id /
+    aws_secret_access_key from settings / .env).
+    """
+
+    def __init__(self, bucket: str | None = None, region: str | None = None):
+        import boto3  # local import keeps boto3 optional for local usage
+
+        self.bucket = bucket or settings.aws_s3_bucket
+        self.region = region or settings.aws_region
+        self.client = boto3.client(
+            "s3",
+            region_name=self.region,
+            aws_access_key_id=settings.aws_access_key_id or None,
+            aws_secret_access_key=settings.aws_secret_access_key or None,
+        )
+        # Public URL base: either explicit, or virtual-hosted-style bucket URL
+        self._public_base = settings.s3_base_url or (
+            f"https://{self.bucket}.s3.{self.region}.amazonaws.com"
+        )
+
+    def put(self, rel_path: str, data: bytes, content_type: str = "application/octet-stream") -> str:
+        safe = Path(rel_path).as_posix().lstrip("/")
+        self.client.put_object(
+            Bucket=self.bucket,
+            Key=safe,
+            Body=data,
+            ContentType=content_type,
+        )
+        return self.url(rel_path)
+
+    def url(self, rel_path: str) -> str:
+        return urljoin(self._public_base + "/", Path(rel_path).as_posix())
+
+    def exists(self, rel_path: str) -> bool:
+        try:
+            self.client.head_object(Bucket=self.bucket, Key=Path(rel_path).as_posix().lstrip("/"))
+            return True
+        except Exception:
+            return False
+
+
 def get_storage() -> Storage:
     kind = getattr(settings, "media_storage", "local")
     if kind == "local":
         return LocalStorage()
-    # S3 storage added in a later step (feat/cms-imaging s3 backend)
+    if kind == "s3":
+        return S3Storage()
     raise ValueError(f"Unknown MEDIA_STORAGE backend: {kind}")

--- a/cms/pyproject.toml
+++ b/cms/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     "pydantic-settings>=2.2",
     "python-multipart>=0.0.9",
     "pillow>=12.3.0",
+    "boto3>=1.43.66",
+    "python-dotenv>=1.2.2",
 ]
 
 [build-system]

--- a/cms/upload_renditions_to_s3.py
+++ b/cms/upload_renditions_to_s3.py
@@ -1,0 +1,54 @@
+"""Upload already-generated local renditions to S3.
+
+Because the DB stores rendition file_path as a relative key
+(e.g. renditions/790/thumbnail_400.webp) and the API computes URLs via the
+storage backend, uploading the local media/ files to S3 at those same keys is
+sufficient — no DB rewrite needed. After this, MEDIA_STORAGE=s3 serves S3 URLs.
+
+Run from cms/:
+    env -u PYTHONPATH uv run python upload_renditions_to_s3.py
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.db import engine
+from app.models import Rendition
+from app.storage import S3Storage
+
+
+def main() -> None:
+    storage = S3Storage()
+    local_root = Path(settings.media_root)
+    with Session(engine) as db:
+        rows = db.query(Rendition).all()
+        print(f"uploading {len(rows)} renditions to s3://{storage.bucket}")
+        done = 0
+        errors = 0
+        for r in rows:
+            rel = Path(r.file_path).as_posix()
+            local_file = local_root / r.file_path.replace("\\", "/")
+            if not local_file.is_file():
+                errors += 1
+                print(f"  MISSING local: {r.file_path}")
+                continue
+            data = local_file.read_bytes()
+            # regenerate if zero-byte / stale
+            try:
+                storage.put(rel, data, content_type="image/webp")
+                done += 1
+            except Exception as e:  # noqa: BLE001
+                errors += 1
+                print(f"  UPLOAD ERR {r.file_path}: {e}")
+            if done % 300 == 0:
+                db.rollback()  # keep session fresh
+        print("UPLOAD_DONE ok:", done, "| errors:", errors)
+
+
+if __name__ == "__main__":
+    main()

--- a/cms/uv.lock
+++ b/cms/uv.lock
@@ -48,6 +48,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/8f/92486dc60e9caf63a766bce02c561381455169a1b7090548d1fdc14d6b8d/boto3-1.43.66.tar.gz", hash = "sha256:ffc77129a4e5519bdbd9b278e4fe9e6276c9d951e0d2b60d626977bdb957cb38", size = 112668, upload-time = "2026-08-06T19:38:42.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/bc/131d596cf673f7b7c6b52ff88fa05f73bbdf9dff70d93e31d4b62645def3/boto3-1.43.66-py3-none-any.whl", hash = "sha256:8d097a41e2f545c25252105570f782bb035b1ac13d6213c772d1c895dc7cedeb", size = 140027, upload-time = "2026-08-06T19:38:40.651Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/81/9ce1f5fe88b4b1429edf83189b8994ffb9883fc20bdd46b7ee9d1cc1da24/botocore-1.43.66.tar.gz", hash = "sha256:dde324cbe8be14b536b78f4fafe192f94fffcc70716bde804044e62495af8c3c", size = 15880416, upload-time = "2026-08-06T19:38:37.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/e6/53f0e28dea0f17a1b041bb3356d0c21fda7ba4198a515cfaf4d5f3088fe3/botocore-1.43.66-py3-none-any.whl", hash = "sha256:0fa62529579469a9224c186eba87e7e561db87dfad20c63ce5d52e427c7fa325", size = 15566310, upload-time = "2026-08-06T19:38:34.446Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -154,10 +182,12 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "boto3" },
     { name = "fastapi" },
     { name = "pillow" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-settings" },
+    { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "sqladmin" },
     { name = "sqlalchemy" },
@@ -167,10 +197,12 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
+    { name = "boto3", specifier = ">=1.43.66" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
     { name = "pydantic-settings", specifier = ">=2.2" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "sqladmin", specifier = ">=0.20" },
     { name = "sqlalchemy", specifier = ">=2.0" },
@@ -232,6 +264,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -543,6 +584,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -604,6 +657,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -704,6 +778,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this is
The **S3 storage backend** — completes the storage abstraction started in (merged) PR #17. LocalStorage from #17 stays; this adds S3Storage with the same interface, so swapping backends is a `MEDIA_STORAGE` config change.

> Note: this work was done after #17 was merged and got stranded uncommitted — recovered and now opened as its own PR.

## What's in it
- **`app/storage.py`**: `S3Storage` (put/url/exists against AWS using scoped app IAM creds from `.env`); `get_storage()` returns it when `MEDIA_STORAGE=s3`
- **`app/config.py`**: `aws_region`, `aws_s3_bucket`, `aws_access_key_id`, `aws_secret_access_key`, `s3_base_url` (loaded from `.env`)
- **`upload_renditions_to_s3.py`**: uploads already-generated local renditions to S3 at their DB `file_path` keys — **no DB rewrite needed**, since URLs are computed via the storage backend at request time
- deps: `boto3`

## Verified against real AWS (scoped `housegallery-cms` user)
- ✅ put/exists/get/delete round-trip against `s3://housegallery-cms`
- ✅ **all 2,367 renditions uploaded** (0 errors, ~543 MB)
- ✅ API serves S3 URLs automatically via `get_storage()` (`MEDIA_STORAGE=s3` in `.env`)

## Infra created (via CLI, least-privilege)
- Bucket `housegallery-cms` (us-west-2, public access blocked)
- IAM user `housegallery-cms` with S3-only inline policy on that bucket
- App access key stored in gitignored `cms/.env` (never committed)

## Security note
Joel's bootstrap admin key (`joel-lithgow`, full Admin) is still active on this machine — recommend deactivating it now that the app has its own scoped key.