### PR TITLE
fix(cms): auto-populate image & rendition URLs in /v1 API

### DIFF
--- a/cms/app/api/v1.py
+++ b/cms/app/api/v1.py
@@ -196,22 +196,4 @@ def get_image(image_id: int, db: Session = Depends(get_db)):
     )
     if row is None:
         raise HTTPException(status_code=404, detail="Image not found")
-    return _image_with_urls(row)
-
-
-def _image_with_urls(img: Image) -> ImageOut:
-    """Serialize an Image, populating rendition URLs via the storage layer."""
-    storage = get_storage()
-    data = ImageOut.model_validate(img)
-    data.file_url = storage.url(img.file_path)
-    data.renditions = []
-    for r in img.renditions:
-        r_out = RenditionOut(
-            filter_spec=r.filter_spec,
-            file_path=r.file_path,
-            width=r.width,
-            height=r.height,
-            url=storage.url(r.file_path),
-        )
-        data.renditions.append(r_out)
-    return data
+    return row

--- a/cms/app/schemas.py
+++ b/cms/app/schemas.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from app.storage import get_storage
 
 
 class ORMModel(BaseModel):
@@ -32,6 +34,12 @@ class RenditionOut(ORMModel):
     height: int
     url: str = ""
 
+    @model_validator(mode="after")
+    def _populate_url(self) -> "RenditionOut":
+        if self.file_path and not self.url:
+            self.url = get_storage().url(self.file_path)
+        return self
+
 
 class ImageOut(ORMModel):
     id: int
@@ -44,6 +52,12 @@ class ImageOut(ORMModel):
     height: int = 0
     file_url: str = ""
     renditions: list[RenditionOut] = []
+
+    @model_validator(mode="after")
+    def _populate_file_url(self) -> "ImageOut":
+        if self.file_path and not self.file_url:
+            self.file_url = get_storage().url(self.file_path)
+        return self
 
 
 class ArtistOut(ORMModel):


### PR DESCRIPTION
## What
Every /v1 endpoint except `/images/{id}` returned images with **empty URLs** — rendering every gallery in the frontend useless.

## Root cause
Only `_image_with_urls()` populated URLs, and it was called in exactly one place.

## Fix
Add Pydantic `model_validator`s to `ImageOut` + `RenditionOut` that ask the storage layer for a URL from each object's `file_path`. Now **all** /v1 responses carry working absolute S3 URLs. Removed the redundant helper.

## Verified
`/v1/artworks`, `/v1/exhibitions/{slug}` now return real rendition URLs (spot-checked).
_Part of a 4-PR stack building the Astro frontend (`feat/astro-frontend`)._