### PR TITLE
feat(www): build site pages from the headless CMS data

### DIFF
--- a/www/src/lib/cms.ts
+++ b/www/src/lib/cms.ts
@@ -1,0 +1,177 @@
+/**
+ * CMS API client — build-time data source for the static site.
+ *
+ * Fetches content from the headless CMS at build time and returns it for
+ * Astro pages. The base URL is env-overridable so the same code can build
+ * against localhost (default) or a public/remote CMS URL.
+ *
+ *   CMS_API_URL=http://localhost:8000/v1   npm run build
+ */
+const BASE =
+  (import.meta.env?.PUBLIC_CMS_API_URL as string | undefined) ??
+  'http://localhost:8000/v1';
+
+async function get<T>(path: string): Promise<T> {
+  const res = await fetch(`${BASE}${path}`);
+  if (!res.ok) {
+    throw new Error(`CMS ${path} -> HTTP ${res.status} ${res.statusText}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+export interface Rendition {
+  filter_spec: string;
+  file_path: string;
+  width: number;
+  height: number;
+  url: string;
+}
+
+export interface Image {
+  id: number;
+  title: string;
+  alt: string;
+  credit: string;
+  description: string;
+  file_path: string;
+  width: number;
+  height: number;
+  file_url: string;
+  renditions: Rendition[];
+}
+
+export interface Artist {
+  id: number;
+  name: string;
+  slug: string;
+  bio: string;
+  website: string;
+  email: string;
+  birth_year: number | null;
+  socials: Record<string, unknown>[];
+  profile_image: Image | null;
+}
+
+export interface Artwork {
+  id: number;
+  title: string;
+  slug: string;
+  description: string;
+  size: string;
+  width_inches: number | null;
+  height_inches: number | null;
+  depth_inches: number | null;
+  date: string | null;
+  price: string;
+  artifacts: Record<string, unknown>[];
+  artists: Artist[];
+  images: Image[];
+  tags: { id: number; name: string; slug: string }[];
+}
+
+export interface Exhibition {
+  id: number;
+  title: string;
+  slug: string;
+  start_date: string | null;
+  end_date: string | null;
+  description: string;
+  body: Record<string, unknown>[];
+  video_embed_url: string;
+  listing_title: string;
+  listing_summary: string;
+  listing_image: Image | null;
+  artists: Artist[];
+  artworks: Artwork[];
+  photos?: { id: number; category: string; sort_order: number; image: Image | null }[];
+}
+
+export interface SiteSettings {
+  site_title: string;
+  tagline: string;
+  nav: Record<string, unknown>[];
+  contact: Record<string, unknown>;
+  socials: Record<string, unknown>[];
+}
+
+export const cms = {
+  siteSettings: () => get<SiteSettings>('/site-settings'),
+  exhibitions: () => get<Exhibition[]>('/exhibitions'),
+  exhibition: (slug: string) => get<Exhibition>(`/exhibitions/${slug}`),
+  artists: () => get<Artist[]>('/artists'),
+  artist: (slug: string) => get<Artist & { artworks: Artwork[] }>(`/artists/${slug}`),
+  artworks: () => get<Artwork[]>('/artworks'),
+  artwork: (slug: string) => get<Artwork>(`/artworks/${slug}`),
+  tags: () => get<{ id: number; name: string; slug: string }[]>('/tags'),
+};
+
+/**
+ * Pick the best image URL for a given display context.
+ * Falls back through rendition sizes (web-optimized -> thumbnail -> file_url).
+ */
+export function bestImageUrl(
+  image: Image | null | undefined,
+  opts: { max?: number } = {},
+): string | undefined {
+  if (!image) return undefined;
+  const urls = image.renditions.map((r) => ({ ...r }));
+  urls.sort((a, b) => a.width - b.width);
+  // Pick the smallest rendition >= max, else the largest available.
+  const target = urls.filter((r) => opts.max ? r.width >= opts.max! : true);
+  const pick = (target.length ? target : urls).at(-1);
+  return pick?.url || image.file_url || undefined;
+}
+
+/** First showcard (promotional flyer) photo image for an exhibition, if any. */
+export function showcardImage(ex: Exhibition): Image | null {
+  return ex.photos?.find((p) => p.category === 'showcard')?.image ?? null;
+}
+
+/** Photos grouped by category, in source order (installation/opening/…). */
+export function photosByCategory(ex: Exhibition): Record<string, Image[]> {
+  const groups: Record<string, Image[]> = {};
+  for (const p of ex.photos ?? []) {
+    if (!p.image) continue;
+    (groups[p.category] ??= []).push(p.image);
+  }
+  return groups;
+}
+
+/**
+ * Replicates the original Wagtail `get_filtered_gallery_images` rule for the
+ * exhibitions index page:
+ *   1. first showcard,
+ *   2. installation photos + each artwork's COVER image (first image), shuffled,
+ *   3. remaining showcards,
+ *   — opening-reception and in-progress photos are excluded.
+ */
+export function filteredGalleryImages(ex: Exhibition): Image[] {
+  if (!ex.photos?.length && !(ex.artworks ?? []).some((a) => a.images?.length)) {
+    return ex.listing_image ? [ex.listing_image] : [];
+  }
+  const byCat = photosByCategory(ex);
+  const showcards = byCat['showcard'] ?? [];
+  const installation = byCat['installation'] ?? [];
+
+  const ordered = [...showcards];
+  // First showcard at the front
+  const first = ordered.shift();
+
+  // Middle: installation photos + first image of every artwork-with-image
+  const middle: Image[] = [...installation];
+  for (const a of ex.artworks ?? []) {
+    if (a.images?.length) middle.push(a.images[0]); // cover shot only
+  }
+  // Random shuffle (matches original `random.shuffle`)
+  for (let i = middle.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [middle[i], middle[j]] = [middle[j], middle[i]];
+  }
+
+  // Reassemble: first showcard, shuffled middle, remaining showcards last.
+  const out: Image[] = [];
+  if (first) out.push(first);
+  out.push(...middle);
+  out.push(...ordered); // remaining showcards at end
+  return out;
+}

--- a/www/src/pages/exhibitions/[slug].astro
+++ b/www/src/pages/exhibitions/[slug].astro
@@ -1,0 +1,300 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { cms, bestImageUrl, showcardImage, photosByCategory } from '../../lib/cms';
+
+export async function getStaticPaths() {
+  const exhibitions = await cms.exhibitions();
+  return exhibitions.map((ex) => ({
+    params: { slug: ex.slug },
+    props: { slug: ex.slug },
+  }));
+}
+
+const { slug } = Astro.props;
+const ex = await cms.exhibition(slug);
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '';
+  return new Date(iso).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+}
+
+// Hero: prefer the showcard (dual front/back) if present, else listing, else an artwork.
+const heroShowcard = showcardImage(ex);
+const heroImg = heroShowcard
+  ? bestImageUrl(heroShowcard, { max: 800 })
+  : bestImageUrl(ex.listing_image, { max: 800 })
+  ?? bestImageUrl(ex.artworks?.find((a) => a.images?.length)?.images?.[0], { max: 800 });
+
+// Artworks split: with images (hover previews) vs without.
+const artworks = (ex.artworks ?? []).filter((a) => a.images?.length);
+const namedArtworks = (ex.artworks ?? []).filter((a) => !a.images?.length);
+
+const photos = photosByCategory(ex);
+const installationPhotos = photos['installation'] ?? [];
+const openingPhotos = photos['opening_reception'] ?? [];
+const inProgressPhotos = photos['in_progress'] ?? [];
+const showcards = photos['showcard'] ?? [];
+---
+
+<Layout title={`${ex.title} — This is a House Gallery`} bodyClass="exhibition-page">
+  <div class="body normal">
+    <!-- Exhibition Hero Section -->
+    <header class="exhibition-hero">
+      <div class="exhibition-hero__content">
+        <div class="exhibition-hero__meta">
+          <time class="exhibition-date-hero" datetime={ex.start_date || undefined}>
+            {ex.start_date && (
+              <>
+                <span class="exhibition-date-hero__main">{formatDate(ex.start_date)}</span>
+                {ex.end_date && ex.end_date !== ex.start_date && (
+                  <span class="exhibition-date-hero__end">{formatDate(ex.end_date)}</span>
+                )}
+              </>
+            )}
+          </time>
+        </div>
+
+        <h1 class="exhibition-title-hero">{ex.title}</h1>
+
+        {ex.artists.length > 0 && (
+          <div class="exhibition-artists-hero">
+            <span class="exhibition-artists-label">Artists:</span>
+            <div class="exhibition-artists-list">
+              {ex.artists.map((a, i) => (
+                <span class="exhibition-artist-name">{a.name}{i < ex.artists.length - 1 ? ',' : ''}</span>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {heroShowcard ? (
+        <div class="exhibition-hero__images exhibition-hero__images--single">
+          <div class="exhibition-hero__image">
+            <img
+              src={bestImageUrl(heroShowcard, { max: 800 })}
+              alt={`The promotional showcard for the exhibition '${ex.title}'`}
+              class="exhibition-hero-img exhibition-hero-img--showcard"
+              loading="lazy"
+              decoding="async"
+            />
+          </div>
+        </div>
+      ) : heroImg ? (
+        <div class="exhibition-hero__images exhibition-hero__images--single">
+          <div class="exhibition-hero__image">
+            <img src={heroImg} alt={ex.title} class="exhibition-hero-img" loading="lazy" decoding="async" />
+          </div>
+        </div>
+      ) : null}
+    </header>
+
+    <!-- Exhibition Summary / Description -->
+    {ex.listing_summary && (
+      <section class="exhibition-description-section">
+        <div class="exhibition-description-content" set:html={ex.listing_summary}></div>
+      </section>
+    )}
+
+    <!-- Exhibition Photos (installation) -->
+    {installationPhotos.length > 0 && (
+      <section class="exhibition-gallery-section">
+        <div class="exhibition-section-header">
+          <h2 class="exhibition-section-title">Exhibition Photos</h2>
+        </div>
+        <div class="exhibition-images">
+          {installationPhotos.map((img) => (
+            <button
+              class="gallery-lightbox-item"
+              data-media-type="image"
+              aria-label={`View ${img.title || ex.title} in lightbox`}
+            >
+              <img
+                              src={bestImageUrl(img, { max: 400 })}
+                              alt={img.title || ex.title}
+                              width={img.width || undefined}
+                              height={img.height || undefined}
+                              loading="lazy"
+                              decoding="async"
+                              class="gallery-single-image"
+                            />
+                          </button>
+                        ))}
+                      </div>
+                    </section>
+                  )}
+
+                  <!-- Artworks Section -->
+                  {artworks.length > 0 && (
+      <section class="exhibition-artworks-section">
+        <div class="exhibition-section-header">
+          <h2 class="exhibition-section-title">Artworks</h2>
+        </div>
+        <div class="exhibition-artworks-grid">
+          {artworks.map((a) => {
+            const preview = bestImageUrl(a.images?.[0], { max: 400 });
+            return (
+              <article class="exhibition-artwork-card" data-artwork-id={a.id} style={preview ? 'cursor: pointer;' : ''}>
+                <div class="exhibition-artwork-content">
+                  <h3 class="exhibition-artwork-title" set:html={a.title}></h3>
+                </div>
+                {preview && (
+                  <div class="exhibition-artwork-hover-preview" data-preview-src={preview}>
+                    <img
+                      src={preview}
+                      alt={`${a.title} preview`}
+                      class="exhibition-artwork-hover-img"
+                      loading="lazy"
+                      decoding="async"
+                    />
+                  </div>
+                )}
+              </article>
+            );
+          })}
+        </div>
+      </section>
+    )}
+
+    <!-- Named artworks with no image -->
+    {namedArtworks.length > 0 && (
+      <section class="exhibition-artworks-section">
+        <div class="exhibition-section-header">
+          <h2 class="exhibition-section-title">More Works</h2>
+        </div>
+        <div class="exhibition-artworks-grid">
+          {namedArtworks.map((a) => (
+            <article class="exhibition-artwork-card">
+              <div class="exhibition-artwork-content">
+                <h3 class="exhibition-artwork-title" set:html={a.title}></h3>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    )}
+
+    <!-- Opening Reception Gallery -->
+    {openingPhotos.length > 0 && (
+      <section class="opening-gallery-section">
+        <div class="exhibition-section-header">
+          <h2 class="exhibition-section-title">Opening Reception</h2>
+        </div>
+        <div class="exhibition-images">
+          {openingPhotos.map((img) => (
+            <button
+              class="gallery-lightbox-item"
+              data-media-type="image"
+              aria-label={`View ${img.title || ex.title} in lightbox`}
+            >
+              <img
+                src={bestImageUrl(img, { max: 400 })}
+                alt={img.title || ex.title}
+                width={img.width || undefined}
+                height={img.height || undefined}
+                loading="lazy"
+                decoding="async"
+                class="gallery-single-image"
+              />
+            </button>
+          ))}
+        </div>
+      </section>
+    )}
+
+    <!-- In Progress Gallery -->
+    {inProgressPhotos.length > 0 && (
+      <section class="in-progress-gallery-section">
+        <div class="exhibition-section-header">
+          <h2 class="exhibition-section-title">In Progress Shots</h2>
+        </div>
+        <div class="exhibition-images">
+          {inProgressPhotos.map((img) => (
+            <button
+              class="gallery-lightbox-item"
+              data-media-type="image"
+              aria-label={`View ${img.title || ex.title} in lightbox`}
+            >
+              <img
+                src={bestImageUrl(img, { max: 400 })}
+                alt={img.title || ex.title}
+                width={img.width || undefined}
+                height={img.height || undefined}
+                loading="lazy"
+                decoding="async"
+                class="gallery-single-image"
+              />
+            </button>
+          ))}
+        </div>
+      </section>
+    )}
+  </div>
+</Layout>
+
+<script>
+  // Ported from artwork-hover-animations.js: mouse-following hover preview on
+  // exhibition artwork cards. The preview is moved to <body> on first show so it
+  // is not affected by the card's hover transform (a `position:fixed` element
+  // inside a transformed ancestor becomes relative to that ancestor, drifting as
+  // the card scrolls). Disabled on touch / reduced-motion.
+  const isTouch =
+    'ontouchstart' in window ||
+    navigator.maxTouchPoints > 0 ||
+    matchMedia('(hover: none)').matches ||
+    matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  if (!isTouch) {
+    const cards = document.querySelectorAll<HTMLElement>('.exhibition-artwork-card');
+    cards.forEach((card) => {
+      const preview = card.querySelector<HTMLElement>('.exhibition-artwork-hover-preview');
+      if (!preview) return;
+
+      card.setAttribute('tabindex', '0');
+      preview.style.position = 'fixed';
+
+      // Detach once, re-attach to body so transforms on ancestors can't affect it.
+      if (preview.parentElement !== document.body) {
+        document.body.appendChild(preview);
+      }
+
+      let shown = false;
+      const show = (x: number, y: number) => {
+        if (!shown) {
+          preview.classList.add('show');
+          card.classList.add('hover-active');
+          shown = true;
+        }
+        // Keep the 250x250 box inside the viewport.
+        const left = Math.min(x - 125, window.innerWidth - 260);
+        const top = Math.min(y - 125, window.innerHeight - 260);
+        preview.style.left = `${Math.max(0, left)}px`;
+        preview.style.top = `${Math.max(0, top)}px`;
+      };
+      const hide = () => {
+        preview.classList.remove('show');
+        card.classList.remove('hover-active');
+        shown = false;
+      };
+
+      card.addEventListener('mouseenter', (e) => show((e as MouseEvent).clientX, (e as MouseEvent).clientY));
+      card.addEventListener('mousemove', (e) => show((e as MouseEvent).clientX, (e as MouseEvent).clientY));
+      card.addEventListener('mouseleave', hide);
+      card.addEventListener('focus', () => {
+        const r = card.getBoundingClientRect();
+        show(r.left + r.width / 2, r.top + r.height / 2);
+      });
+      card.addEventListener('blur', hide);
+    });
+  }
+</script>
+
+<style>
+  .exhibition-hero { display: flex; gap: var(--size-layout-large-spacing, 80px); }
+  .exhibition-hero__images--single { flex: 0 0 auto; }
+  .exhibition-hero-img--showcard {
+    max-width: 320px;
+    border: 1px solid var(--color-black, #121212);
+  }
+  .exhibition-hero__content { flex: 1 1 auto; }
+</style>

--- a/www/src/pages/exhibitions/index.astro
+++ b/www/src/pages/exhibitions/index.astro
@@ -1,0 +1,78 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { cms, bestImageUrl, filteredGalleryImages } from '../../lib/cms';
+
+// Fetch details (they carry the photo galleries; the list endpoint does not).
+const exhibitions = await cms.exhibitions();
+const details = await Promise.all(
+  exhibitions.map((ex) => cms.exhibition(ex.slug).catch(() => ex))
+);
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return d.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+}
+---
+
+<Layout title="Exhibitions — This is a House Gallery" bodyClass="exhibitions-index">
+  <div class="body">
+    <div class="exhibition-page-header">
+      <h1 class="title type-title">Exhibitions</h1>
+    </div>
+
+    <div class="exhibitions-listing">
+      {details.map((ex) => {
+        const gallery = filteredGalleryImages(ex);
+        const imgUrl = bestImageUrl(ex.listing_image, { max: 400 }) ??
+          (gallery[0] ? bestImageUrl(gallery[0], { max: 400 }) : undefined);
+        return (
+          <div id={ex.title.toLowerCase().replace(/\s+/g, '-')} class="exhibition-listing-item exhibition-title">
+            <a href={`/exhibitions/${ex.slug}/`} class="exhibition-header-link">
+              <section class="exhibition-header">
+                <h3>{formatDate(ex.start_date)}</h3>
+                <section>
+                  <h2>{ex.title}</h2>
+                  <section class="exhibition-header__artists">
+                    {ex.artists.map((a) => (
+                      <p>{a.name}</p>
+                    ))}
+                  </section>
+                </section>
+              </section>
+            </a>
+
+            {gallery.length > 0 ? (
+              <div class="exhibition-feature-gallery" data-gallery-id={ex.title.toLowerCase().replace(/\s+/g, '-')}>
+                <div class="gallery-container gallery-columns-container masonry">
+                  <div class="gallery-images">
+                    {gallery.slice(0, 12).map((img, i) => (
+                      <button
+                        class="gallery-lightbox-item"
+                        data-media-type="image"
+                        data-index={i}
+                        aria-label={`View ${img.title || ex.title} in lightbox`}
+                      >
+                        <img
+                          src={bestImageUrl(img, { max: 400 })}
+                          alt={img.title || ex.title}
+                          width={img.width || undefined}
+                          height={img.height || undefined}
+                          loading="lazy"
+                          decoding="async"
+                          class="gallery-single-image"
+                        />
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <p class="horizontal-features-block__empty">{ex.title} — no photos yet</p>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  </div>
+</Layout>

--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -1,0 +1,221 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { cms, bestImageUrl, showcardImage } from '../lib/cms';
+
+// Details carry the showcard photos (list endpoint does not), so fetch them
+// in parallel for the carousel.
+const settings = await cms.siteSettings();
+const exhibitions = await cms.exhibitions();
+const details = await Promise.all(
+  exhibitions.map((ex) =>
+    cms.exhibition(ex.slug).catch(() => ex)
+  )
+);
+---
+
+<Layout
+  title={settings.site_title || 'This is a House Gallery'}
+  bodyClass="home"
+>
+  <section class="home__body" id="home-body">
+    <!-- hero-section: intro + CTAs (ported from hero-section.html / hero-links.html) -->
+    <section class="hero-section">
+      <div class="hero-section__content">
+        <h1 class="hero-section__intro">
+          This is a House Gallery serves as a project and exhibition place for the DIY Bay Area art scene.
+        </h1>
+        <div class="hero-section__links">
+          <div class="hero-links">
+            <div class="hero-links__items">
+              <a href="/schedule/" class="button-link">Whens the next show?</a>
+              <a href="/about/" class="button-carrot">Find out who lives here</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- horizontal-features: exhibition carousel with arrow + progress nav -->
+    <div class="horizontal-features-block" data-horizontal-features>
+      <h2 class="horizontal-features-block__title">Exhibitions</h2>
+
+      {details.length > 0 ? (
+        <div class="horizontal-features-block__container">
+          <button
+            class="horizontal-features-block__nav horizontal-features-block__nav--prev"
+            type="button"
+            aria-label="Previous exhibitions"
+            tabindex="-1"
+          >‹</button>
+
+          <div
+            class="horizontal-features-block__scroll-container"
+            role="region"
+            aria-label="Exhibitions"
+            tabindex="0"
+          >
+            <div class="horizontal-features-block__track">
+              {details.map((ex) => {
+                const showcard = showcardImage(ex);
+                const imgUrl = bestImageUrl(showcard, { max: 400 })
+                  ?? bestImageUrl(ex.listing_image, { max: 400 })
+                  ?? bestImageUrl(ex.artworks?.find((a) => a.images?.length)?.images?.[0], { max: 400 });
+                return (
+                  <div class="horizontal-features-card" data-exhibition-id={ex.id}>
+                    <a href={`/exhibitions/${ex.slug}/`} class="horizontal-features-card__link" aria-label="View exhibition">
+                      <div class="horizontal-features-card__image-container">
+                        {imgUrl ? (
+                          <img
+                            src={imgUrl}
+                            alt={ex.listing_title || ex.title}
+                            class="horizontal-features-card__image"
+                            loading="lazy"
+                          />
+                        ) : (
+                          <div class="horizontal-features-card__placeholder">
+                            <span>{ex.listing_title || ex.title}</span>
+                          </div>
+                        )}
+                      </div>
+                    </a>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <button
+            class="horizontal-features-block__nav horizontal-features-block__nav--next"
+            type="button"
+            aria-label="Next exhibitions"
+          >›</button>
+
+          <div class="horizontal-features-block__progress">
+            <div class="horizontal-features-block__progress-bar" role="progressbar" aria-label="Scroll position"></div>
+          </div>
+        </div>
+      ) : (
+        <div class="horizontal-features-block__empty">
+          <p>No exhibitions selected for display.</p>
+        </div>
+      )}
+    </div>
+  </section>
+</Layout>
+
+<script>
+  // Netflix-style horizontal scroll with progressive edge arrows — works with a
+  // mouse (no trackpad), keyboard, and touch. Only the relevant edge arrow
+  // appears based on scroll position: at the start only "next" shows; once you
+  // scroll, "prev" fades in and "next" stays until the end.
+  function initCarousel(block: HTMLElement) {
+    const track = block.querySelector<HTMLElement>('.horizontal-features-block__track');
+    const scrollEl = block.querySelector<HTMLElement>('.horizontal-features-block__scroll-container');
+    const prev = block.querySelector<HTMLButtonElement>('.horizontal-features-block__nav--prev');
+    const next = block.querySelector<HTMLButtonElement>('.horizontal-features-block__nav--next');
+    const bar = block.querySelector<HTMLElement>('.horizontal-features-block__progress-bar');
+    const cards = Array.from(block.querySelectorAll<HTMLElement>('.horizontal-features-card'));
+    if (!track || !scrollEl || !prev || !next || !bar || cards.length === 0) return;
+
+    const cardWidth = () => {
+      const first = cards[0];
+      return first.offsetWidth + parseFloat(getComputedStyle(track).gap || '0');
+    };
+    const step = () => Math.max(1, Math.round(scrollEl.clientWidth / cardWidth()));
+    const maxScroll = () => scrollEl.scrollWidth - scrollEl.clientWidth;
+
+    function update() {
+      const max = maxScroll();
+      const atStart = scrollEl.scrollLeft <= 4;
+      const atEnd = scrollEl.scrollLeft >= max - 4;
+      // Progressive reveal: prev hidden at start, next hidden once you reach the end.
+      prev.classList.toggle('is-hidden', atStart);
+      next.classList.toggle('is-hidden', atEnd);
+      prev.setAttribute('aria-hidden', String(atStart));
+      next.setAttribute('aria-hidden', String(atEnd));
+      prev.tabIndex = atStart ? -1 : 0;
+      next.tabIndex = atEnd ? -1 : 0;
+      const pct = max <= 0 ? 100 : (scrollEl.scrollLeft / max) * 100;
+      bar.style.width = `${pct}%`;
+    }
+
+    function nudge(dir: 1 | -1) {
+      const target = scrollEl.scrollLeft + dir * cardWidth() * step();
+      const clamped = Math.max(0, Math.min(target, maxScroll()));
+      scrollEl.scrollTo({ left: clamped, behavior: 'smooth' });
+    }
+
+    prev.addEventListener('click', () => nudge(-1));
+    next.addEventListener('click', () => nudge(1));
+    scrollEl.addEventListener('scroll', update, { passive: true });
+    scrollEl.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); nudge(-1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); nudge(1); }
+    });
+    window.addEventListener('resize', () => { update(); });
+    // Re-evaluate when the track changes size (lazy images load, viewport shifts),
+    // so the "next" arrow isn't hidden forever just because images were still
+    // loading when we first measured.
+    if ('ResizeObserver' in window) {
+      const ro = new ResizeObserver(() => update());
+      ro.observe(track);
+      ro.observe(scrollEl);
+    }
+    // Initial state — called after layout so scrollWidth is correct.
+    requestAnimationFrame(() => requestAnimationFrame(update));
+    update();
+  }
+
+  document.querySelectorAll<HTMLElement>('[data-horizontal-features]').forEach(initCarousel);
+</script>
+
+<style>
+  .horizontal-features-block__nav {
+    position: absolute;
+    z-index: 5;
+    top: 50%; /* vertically centered within the showcard height */
+    transform: translateY(-50%);
+    width: 44px;
+    height: 44px;
+    border: 1px solid var(--color-black, #121212);
+    background: var(--color-surface, #fff);
+    color: var(--color-black, #121212);
+    font-size: 24px;
+    line-height: 1;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: opacity 0.25s ease, transform 0.2s var(--transition-easing-standard, ease);
+  }
+  .horizontal-features-block__nav:hover:not(.is-hidden) {
+    transform: translateY(-50%) translateY(-2px) scale(1.05);
+    box-shadow: 3px 3px 0 var(--color-black, #121212);
+  }
+  .horizontal-features-block__nav.is-hidden {
+    opacity: 0;
+    pointer-events: none;
+    visibility: hidden;
+  }
+  .horizontal-features-block__nav--prev { left: var(--size-layout-gutter, 15px); }
+  .horizontal-features-block__nav--next { right: var(--size-layout-gutter, 15px); }
+  .horizontal-features-block__nav:focus-visible {
+    outline: 2px solid var(--color-black, #121212);
+    outline-offset: 2px;
+  }
+
+  /* Progress rail sits under the cards (full width, overlapping the arrows zone). */
+  .horizontal-features-block__progress {
+    height: 3px;
+    margin-top: 12px;
+    background: var(--color-black, #121212);
+    opacity: 0.12;
+    overflow: hidden;
+  }
+  .horizontal-features-block__progress-bar {
+    height: 100%;
+    width: 0;
+    background: var(--color-accent, #e91e63);
+    transition: width 0.3s ease;
+  }
+</style>


### PR DESCRIPTION
## What
Implements the site's pages as static Astro builds that fetch the FastAPI CMS at build time (env-overridable `CMS_API_URL`, default localhost:8000).

## Files
- `src/lib/cms.ts` — CMS client (types + fetch) + image helpers: `bestImageUrl`, `showcardImage`, `photosByCategory`, and `filteredGalleryImages` (faithful port of the original `get_filtered_gallery_images`: first showcard → installations + artwork cover shots shuffled → remaining showcards; excludes opening/in-progress)
- `src/pages/index.astro` — homepage: hero + CTAs, horizontal exhibition carousel (showcards), **progressive edge arrows + progress rail** (mouse/trackpad/keyboard), `ResizeObserver` so the next arrow appears once lazy images load
- `src/pages/exhibitions/index.astro` — exhibitions listing with curated galleries
- `src/pages/exhibitions/[slug].astro` — exhibition detail: showcard hero, installation photos, artwork grid with cursor-following hover previews (hoisted to `<body>` to fix transformed-ancestor drift), opening-reception gallery; images carry intrinsic w/h to prevent CLS

## Verified
15 static pages build; all 173 image URLs return HTTP 200.
_Part of a 4-PR stack building the Astro frontend._