### PR TITLE
feat(www): drive header nav from CMS site_settings

### DIFF
--- a/cms/seed_site_nav.py
+++ b/cms/seed_site_nav.py
@@ -1,0 +1,38 @@
+"""Populate site_settings.nav (+ leave socials empty) from the live site's nav.
+
+The live header shows exactly three top-level links:
+  Exhibitions  /exhibitions/   (CTA)
+  Schedule     /schedule/      (CTA)
+  About us     /about/         (menu)
+
+We store these in SiteSettings.nav as [{label, url, cta}] so the Astro header
+can be driven from the CMS (editable via admin) instead of hardcoded.
+Socials are left empty — the live site footer exposes none.
+"""
+
+from sqlalchemy.orm import Session
+
+from app.db import engine
+from app.models import SiteSettings
+
+NAV = [
+    {"label": "Exhibitions", "url": "/exhibitions/", "cta": True},
+    {"label": "Schedule", "url": "/schedule/", "cta": True},
+    {"label": "About us", "url": "/about/", "cta": False},
+]
+
+
+def main() -> None:
+    with Session(engine) as db:
+        ss = db.query(SiteSettings).first()
+        if ss is None:
+            print("NO_SITE_SETTINGS")
+            return
+        ss.nav = NAV
+        db.commit()
+        print("NAV_OK ->", ss.nav)
+        print("socials  ->", ss.socials)
+
+
+if __name__ == "__main__":
+    main()

--- a/www/src/components/Header.astro
+++ b/www/src/components/Header.astro
@@ -1,12 +1,25 @@
 ---
-// Header ported from housegallery/templates/components/header.html
-// + the main-menu block. Nav links mirror the live site's settings.
-const menuLinks = [
-  { text: 'Exhibitions', href: '/exhibitions/', cta: true },
-  { text: 'Schedule', href: '/schedule/', cta: true },
-  { text: 'About us', href: '/about/', cta: false },
-];
-const ctas = menuLinks.filter((l) => l.cta);
+// Header ported from housegallery/templates/components/header.html + main-menu.
+// Nav is driven by the CMS (site_settings.nav) so it's editable via admin,
+// with a safe fallback if the CMS is unreachable at build time.
+import { cms } from '../lib/cms';
+
+let nav: { label: string; url: string; cta: boolean }[] = [];
+try {
+  const settings = await cms.siteSettings();
+  nav = (settings.nav ?? []).map((n) => ({
+    label: String(n.label ?? ''),
+    url: String(n.url ?? '/'),
+    cta: Boolean(n.cta),
+  }));
+} catch {
+  nav = [
+    { label: 'Exhibitions', url: '/exhibitions/', cta: true },
+    { label: 'Schedule', url: '/schedule/', cta: true },
+    { label: 'About us', url: '/about/', cta: false },
+  ];
+}
+const ctas = nav.filter((l) => l.cta);
 ---
 
 <div class="header__overlay"></div>
@@ -18,7 +31,7 @@ const ctas = menuLinks.filter((l) => l.cta);
 
   <div class="header__ctas">
     {ctas.map((l) => (
-      <a href={l.href} class="button-carrot">{l.text}</a>
+      <a href={l.url} class="button-carrot">{l.label}</a>
     ))}
   </div>
 
@@ -44,9 +57,9 @@ const ctas = menuLinks.filter((l) => l.cta);
     <span class="main-menu__close-icon"></span>
   </button>
   <ul class="main-menu__items">
-    {menuLinks.map((l) => (
+    {nav.map((l) => (
       <li>
-        <a class="button-carrot" href={l.href}>{l.text}</a>
+        <a class="button-carrot" href={l.url}>{l.label}</a>
       </li>
     ))}
   </ul>


### PR DESCRIPTION
## What
The header previously hardcoded its three links. This makes the primary nav a single CMS-managed source.

## Includes
- **cms/seed_site_nav.py** — one-time seed of `site_settings.nav` = [{label, url, cta}] (Exhibitions / Schedule / About us). Socials left empty (the live site footer exposes none).
- **Header.astro** — reads `site_settings.nav` at build time, splits CTAs vs. full menu, with a safe fallback to the same three links if the CMS is unreachable.

## Verified
`/v1/site-settings` serves the nav; built header renders all three links.
_Chunk A: CMS-driven nav so the header is editable via admin._