### PR TITLE
feat(www): add /schedule/ and /about/ pages

### DIFF
--- a/cms/seed_site_contact.py
+++ b/cms/seed_site_contact.py
@@ -1,0 +1,27 @@
+"""Update site_settings.contact + socials for the About "Get in Touch" aside."""
+from sqlalchemy.orm import Session
+
+from app.db import engine
+from app.models import SiteSettings
+
+CONTACT = {"email": "thisisahousegallery@gmail.com"}
+SOCIALS = [
+    {"label": "@thisisahousegallery", "platform": "instagram", "url": "https://instagram.com/thisisahousegallery"},
+]
+
+
+def main() -> None:
+    with Session(engine) as db:
+        ss = db.query(SiteSettings).first()
+        if ss is None:
+            print("NO_SITE_SETTINGS")
+            return
+        ss.contact = CONTACT
+        ss.socials = SOCIALS
+        db.commit()
+        print("CONTACT_OK email=", ss.contact.get("email"))
+        print("SOCIALS_OK ->", ss.socials)
+
+
+if __name__ == "__main__":
+    main()

--- a/www/src/components/PageHeader.astro
+++ b/www/src/components/PageHeader.astro
@@ -1,0 +1,30 @@
+---
+// Shared page header used across top-level pages (About / Schedule / Exhibitions).
+// Mirrors the design system's canonical exhibition-page-header treatment so every
+// page title starts in the same place with the same spacing and bottom rule.
+interface Props {
+  title: string;
+  intro?: string;
+}
+const { title, intro } = Astro.props;
+---
+
+<header class="page-header">
+  <h1 class="page-header__title title type-title">{title}</h1>
+  {intro && <p class="page-header__intro type-intro">{intro}</p>}
+</header>
+
+<style>
+  .page-header {
+    padding: var(--size-layout-heading-spacing, 30px) var(--size-layout-gutter, 15px);
+    border-bottom: 1px solid var(--color-black, #121212);
+  }
+  .page-header__title { margin: 0; }
+  /* Intro is optional and styled smaller/subdued, not window-dressing. */
+  .page-header__intro {
+    margin: var(--size-layout-element-spacing, 25px) 0 0;
+    max-width: 600px;
+    font-size: var(--font-size-body, 16px);
+    opacity: 0.8;
+  }
+</style>

--- a/www/src/components/ProgramRow.astro
+++ b/www/src/components/ProgramRow.astro
@@ -1,0 +1,84 @@
+---
+// A single show row in the schedule program listing.
+import { bestImageUrl, type EventItem, type Exhibition } from '../lib/cms';
+
+interface Props {
+  ex: Exhibition;
+  eventsByShow: Map<string, EventItem[]>;
+}
+
+const { ex, eventsByShow } = Astro.props;
+const related = eventsByShow.get(norm(ex.title)) ?? [];
+const img = bestImageUrl(ex.listing_image, { max: 400 })
+  ?? bestImageUrl(ex.artworks?.find((a) => a.images?.length)?.images?.[0], { max: 400 });
+
+function norm(s: string) {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+function fmtRange(ex: Exhibition): string {
+  const s = ex.start_date ? new Date(ex.start_date) : null;
+  const e = ex.end_date ? new Date(ex.end_date) : null;
+  if (!s) return '';
+  const sTxt = s.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+  if (!e || e.getTime() === s.getTime()) return sTxt;
+  return `${sTxt} – ${e.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}`;
+}
+function fmtEventDate(ev: EventItem): string {
+  const d = ev.start_date ? new Date(ev.start_date) : null;
+  if (!d) return '';
+  let s = d.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+  if (ev.start_time) s += ' · ' + new Date(ev.start_time).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+  return s;
+}
+function eventKind(ev: EventItem): string {
+  return (ev.event_type || '').replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+---
+
+<div class="program-item" id={ex.title.toLowerCase().replace(/\s+/g, '-')}>
+  <a href={`/exhibitions/${ex.slug}/`} class="program-item__main">
+    <div class="program-item__date">{fmtRange(ex)}</div>
+    <div class="program-item__body">
+      <h3 class="program-item__title">{ex.title}</h3>
+      {ex.artists?.length > 0 && (
+        <div class="program-item__artists">
+          {ex.artists.map((a, i) => (
+            <span>{a.name}{i < ex.artists.length - 1 ? ', ' : ''}</span>
+          ))}
+        </div>
+      )}
+    </div>
+    {img && <img src={img} alt={ex.title} class="program-item__thumb" loading="lazy" />}
+  </a>
+
+  {related.map((ev) => (
+    <div class="program-item__event">
+      <span class="program-item__event-badge">{eventKind(ev)}</span>
+      <span class="program-item__event-date">{fmtEventDate(ev)}</span>
+    </div>
+  ))}
+</div>
+
+<style>
+  .program-item { border-bottom: 1px solid var(--color-black, #121212); }
+  .program-item:last-child { border-bottom: none; }
+  .program-item__main {
+    display: grid;
+    grid-template-columns: minmax(180px, 260px) 1fr auto;
+    gap: var(--size-layout-element-spacing, 25px);
+    align-items: center;
+    padding: var(--size-layout-element-spacing, 25px) 0;
+    text-decoration: none;
+    color: inherit;
+    transition: background 0.2s ease;
+  }
+  .program-item__main:hover { background: var(--color-surface-variant, #f5f5f5); }
+  .program-item__date { font-size: var(--font-size-small, 14px); opacity: 0.7; }
+  .program-item__title { font-family: var(--font-family-heading, monospace); font-weight: var(--font-weight-light, 100); font-size: var(--font-size-subheading, 20px); margin: 0; }
+  .program-item__artists { font-size: var(--font-size-small, 14px); opacity: 0.7; margin-top: 0.25rem; }
+  .program-item__thumb { width: 120px; height: 120px; object-fit: cover; border: 1px solid var(--color-black, #121212); }
+  .program-item__event { display: flex; gap: 0.75rem; align-items: center; padding: 0 0 var(--size-layout-element-spacing, 25px) 0; font-size: var(--font-size-small, 14px); }
+  .program-item__event-badge { background: var(--color-accent, #e91e63); color: #fff; padding: 0.15rem 0.5rem; text-transform: uppercase; font-size: 10px; letter-spacing: 0.05em; }
+  .program-item__event-date { opacity: 0.8; }
+</style>

--- a/www/src/components/ProgramRow.astro
+++ b/www/src/components/ProgramRow.astro
@@ -1,20 +1,32 @@
 ---
 // A single show row in the schedule program listing.
-import { bestImageUrl, type EventItem, type Exhibition } from '../lib/cms';
+import { bestImageUrl, photosByCategory, type EventItem, type Exhibition } from '../lib/cms';
 
 interface Props {
   ex: Exhibition;
-  eventsByShow: Map<string, EventItem[]>;
+  nonOpeningEvents: EventItem[];
 }
 
-const { ex, eventsByShow } = Astro.props;
-const related = eventsByShow.get(norm(ex.title)) ?? [];
-const img = bestImageUrl(ex.listing_image, { max: 400 })
-  ?? bestImageUrl(ex.artworks?.find((a) => a.images?.length)?.images?.[0], { max: 400 });
+const { ex, nonOpeningEvents } = Astro.props;
 
-function norm(s: string) {
-  return s.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
-}
+// Thumbnail priority: opening photos (best captures the event) -> installation
+// -> showcard -> an artwork cover, so we never fall back to a random shot.
+const photos = photosByCategory(ex);
+const openingImg = photos['opening_reception']?.[0];
+const installImg = photos['installation']?.[0];
+const showcardImg = photos['showcard']?.[0];
+const artworkImg = ex.artworks?.find((a) => a.images?.length)?.images?.[0];
+const img = bestImageUrl(openingImg, { max: 400 })
+  ?? bestImageUrl(installImg, { max: 400 })
+  ?? bestImageUrl(showcardImg, { max: 400 })
+  ?? bestImageUrl(artworkImg, { max: 400 });
+
+// Every exhibition IS an opening reception, on its start date. Derive the
+// opening badge directly rather than relying on the sparse events table.
+const start = ex.start_date ? new Date(ex.start_date) : null;
+const openingDate = start
+  ? start.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+  : '';
 
 function fmtRange(ex: Exhibition): string {
   const s = ex.start_date ? new Date(ex.start_date) : null;
@@ -52,9 +64,18 @@ function eventKind(ev: EventItem): string {
     {img && <img src={img} alt={ex.title} class="program-item__thumb" loading="lazy" />}
   </a>
 
-  {related.map((ev) => (
+  {/* Every show has an opening reception on its start date. */}
+  {openingDate && (
     <div class="program-item__event">
-      <span class="program-item__event-badge">{eventKind(ev)}</span>
+      <span class="program-item__event-badge">Exhibition Opening</span>
+      <span class="program-item__event-date">{openingDate}</span>
+    </div>
+  )}
+
+  {/* Non-opening programming (talks, workshops, closings…) reserved from events. */}
+  {nonOpeningEvents.map((ev) => (
+    <div class="program-item__event">
+      <span class="program-item__event-badge program-item__event-badge--alt">{eventKind(ev)}</span>
       <span class="program-item__event-date">{fmtEventDate(ev)}</span>
     </div>
   ))}
@@ -79,6 +100,7 @@ function eventKind(ev: EventItem): string {
   .program-item__artists { font-size: var(--font-size-small, 14px); opacity: 0.7; margin-top: 0.25rem; }
   .program-item__thumb { width: 120px; height: 120px; object-fit: cover; border: 1px solid var(--color-black, #121212); }
   .program-item__event { display: flex; gap: 0.75rem; align-items: center; padding: 0 0 var(--size-layout-element-spacing, 25px) 0; font-size: var(--font-size-small, 14px); }
-  .program-item__event-badge { background: var(--color-accent, #e91e63); color: #fff; padding: 0.15rem 0.5rem; text-transform: uppercase; font-size: 10px; letter-spacing: 0.05em; }
+  .program-item__event-badge { background: var(--color-black, #121212); color: #fff; padding: 0.15rem 0.5rem; text-transform: uppercase; font-size: 10px; letter-spacing: 0.05em; }
+  .program-item__event-badge--alt { background: var(--color-accent, #e91e63); }
   .program-item__event-date { opacity: 0.8; }
 </style>

--- a/www/src/lib/cms.ts
+++ b/www/src/lib/cms.ts
@@ -130,6 +130,7 @@ export const cms = {
   artwork: (slug: string) => get<Artwork>(`/artworks/${slug}`),
   tags: () => get<{ id: number; name: string; slug: string }[]>('/tags'),
     events: () => get<EventItem[]>('/events'),
+    image: (id: number) => get<Image>(`/images/${id}`),
   };
 
 /**

--- a/www/src/lib/cms.ts
+++ b/www/src/lib/cms.ts
@@ -94,6 +94,32 @@ export interface SiteSettings {
   socials: Record<string, unknown>[];
 }
 
+export interface EventItem {
+  id: number;
+  title: string;
+  slug: string;
+  event_type: string;
+  tagline: string;
+  start_date: string | null;
+  end_date: string | null;
+  start_time: string | null;
+  end_time: string | null;
+  all_day: boolean;
+  custom_venue_name: string;
+  custom_address: string;
+  location_details: string;
+  description: string;
+  capacity: number | null;
+  registration_required: boolean;
+  registration_link: string;
+  ticket_price: string;
+  contact_email: string;
+  external_link: string;
+  featured_on_schedule: boolean;
+  related_exhibition: Exhibition | null;
+  featured_image: Image | null;
+}
+
 export const cms = {
   siteSettings: () => get<SiteSettings>('/site-settings'),
   exhibitions: () => get<Exhibition[]>('/exhibitions'),
@@ -103,7 +129,8 @@ export const cms = {
   artworks: () => get<Artwork[]>('/artworks'),
   artwork: (slug: string) => get<Artwork>(`/artworks/${slug}`),
   tags: () => get<{ id: number; name: string; slug: string }[]>('/tags'),
-};
+    events: () => get<EventItem[]>('/events'),
+  };
 
 /**
  * Pick the best image URL for a given display context.

--- a/www/src/pages/about.astro
+++ b/www/src/pages/about.astro
@@ -1,8 +1,8 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import PageHeader from '../components/PageHeader.astro';
 import { cms, bestImageUrl } from '../lib/cms';
 
-let tagline = 'This is a House Gallery serves as a project and exhibition space for the DIY Bay Area art scene.';
 let email = '';
 let instagram = '';
 let instagramUrl = '';
@@ -11,7 +11,6 @@ let instagramUrl = '';
 let houseImage = '';
 try {
   const settings = await cms.siteSettings();
-  if (settings.tagline) tagline = settings.tagline;
   const contact = (settings.contact ?? {}) as Record<string, unknown>;
   if (typeof contact.email === 'string' && contact.email) email = contact.email;
   const socials = (settings.socials ?? []) as Record<string, unknown>[];
@@ -32,10 +31,7 @@ if (!instagramUrl) instagramUrl = 'https://instagram.com/thisisahousegallery';
 
 <Layout title="About — This is a House Gallery" bodyClass="about-page">
   <div class="body">
-    <header class="about-hero">
-      <h1 class="title type-title">About</h1>
-      <p class="type-intro">{tagline}</p>
-    </header>
+    <PageHeader title="About" />
 
     <div class="about-layout">
       <div class="about-main">
@@ -87,11 +83,8 @@ if (!instagramUrl) instagramUrl = 'https://instagram.com/thisisahousegallery';
 </Layout>
 
 <style>
-  .about-hero { padding: var(--size-layout-heading-spacing, 30px) var(--size-layout-gutter, 15px); border-bottom: 1px solid var(--color-black, #121212); }
-  .about-hero .type-intro { max-width: 640px; margin-top: var(--size-layout-element-spacing, 25px); }
-
-  /* Align the layout's left edge with the header/title gutter so the body
-     text lines up with the intro instead of being centered in its own column. */
+  /* Align the body layout's left edge with the shared page-header gutter so
+     the text lines up with the page title instead of sitting its own column. */
   .about-layout {
     display: grid;
     grid-template-columns: 1fr;

--- a/www/src/pages/about.astro
+++ b/www/src/pages/about.astro
@@ -68,13 +68,17 @@ if (!instagramUrl) instagramUrl = 'https://instagram.com/thisisahousegallery';
               <img src={houseImage} alt="The gallery space" class="about-contact__img" loading="lazy" />
             )}
             {email && (
-              <p class="about-contact__line">
-                <a class="email-link" href={`mailto:${email}`}>{email}</a>
+              <p class="social-media-link__item">
+                <span class="social-media-link__icon" aria-hidden="true">✉</span>
+                <a class="social-media-link__text" href={`mailto:${email}`}>{email}</a>
               </p>
             )}
-            <a class="about-contact__line" href={instagramUrl} target="_blank" rel="noopener">
-              {instagram}
-            </a>
+            <p class="social-media-link__item social-media-link__item--instagram">
+              <span class="social-media-link__icon" aria-hidden="true">◎</span>
+              <a class="social-media-link__text" href={instagramUrl} target="_blank" rel="noopener">
+                {instagram}
+              </a>
+            </p>
           </div>
         </section>
       </aside>
@@ -103,15 +107,25 @@ if (!instagramUrl) instagramUrl = 'https://instagram.com/thisisahousegallery';
   .about-block:last-child { margin-bottom: 0; }
   .about-block .type-subheading { margin-bottom: var(--size-layout-element-spacing, 25px); }
   .about-block .type-body { line-height: 1.8; }
-  .about-block a { color: var(--color-accent, #e91e63); text-decoration: underline; text-underline-offset: 3px; }
-  .about-block a:hover { background: var(--color-accent, #e91e63); color: #fff; }
+  /* Body links follow the site's standard black + underline convention. */
+  .about-block .type-body a {
+    color: var(--color-black, #121212);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    font-weight: var(--font-weight-normal, 400);
+  }
+  .about-block .type-body a:hover { background: var(--color-hover-background, #efefef); }
 
   .about-aside { border-left: 1px solid var(--color-black, #121212); padding-left: var(--size-layout-section-spacing, 48px); }
   @media (min-width: 900px) { .about-aside { position: sticky; top: 40px; } }
   @media (max-width: 899px) { .about-aside { border-left: none; border-top: 1px solid var(--color-black, #121212); padding-left: 0; padding-top: var(--size-layout-section-spacing, 48px); } }
 
-  .about-contact__card { display: flex; flex-direction: column; gap: 1rem; }
-  .about-contact__img { width: 100%; max-width: 240px; border: 1px solid var(--color-black, #121212); }
-  .about-contact__line { font-size: var(--font-size-body, 16px); color: var(--color-accent, #e91e63); text-decoration: underline; text-underline-offset: 3px; }
-  .about-contact__line:hover { background: var(--color-accent, #e91e63); color: #fff; }
+  .about-contact__card {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
+  .about-contact__card .social-media-link__item { margin: 0; padding: 0.4rem 0; }
+  .about-contact__img { width: 100%; max-width: 260px; border: 1px solid var(--color-black, #121212); margin-bottom: 0.75rem; }
 </style>

--- a/www/src/pages/about.astro
+++ b/www/src/pages/about.astro
@@ -1,0 +1,73 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { cms } from '../lib/cms';
+
+let tagline = 'This is a House Gallery serves as a project and exhibition place for the DIY Bay Area art scene.';
+let contact: Record<string, unknown> = {};
+try {
+  const settings = await cms.siteSettings();
+  if (settings.tagline) tagline = settings.tagline;
+  contact = settings.contact ?? {};
+} catch {
+  /* CMS unreachable — use defaults */
+}
+const email = typeof contact.email === 'string' ? contact.email : '';
+---
+
+<Layout title="About — This is a House Gallery" bodyClass="about-page">
+  <div class="body">
+    <header class="about-hero">
+      <h1 class="title type-title">About</h1>
+      <p class="type-intro">{tagline}</p>
+    </header>
+
+    <section class="about-body">
+      <div class="about-block">
+        <h2 class="type-subheading">The House</h2>
+        <p class="type-body">
+          This is a House Gallery is a project and exhibition space run out of a
+          house in the East Bay. We make room for the DIY Bay Area art scene —
+          the artists, objects, and communities that don’t always fit the white
+          cube — turning the domestic into a place to show, gather, and argue
+          about what art is for.
+        </p>
+      </div>
+
+      <div class="about-block">
+        <h2 class="type-subheading">Program</h2>
+        <p class="type-body">
+          Exhibitions change month to month, each one an installation in the
+          space and a conversation with the people who made it. Openings are
+          free and open — come through, look close, say hello. See the{" "}
+          <a href="/schedule/">schedule</a> for what’s on, and browse past shows
+          under <a href="/exhibitions/">exhibitions</a>.
+        </p>
+      </div>
+
+      <div class="about-block">
+        <h2 class="type-subheading">Get in Touch</h2>
+        {email ? (
+          <p class="type-body">
+            For inquiries, submissions, or just to say hi, write to{" "}
+            <a class="email-link" href={`mailto:${email}`}>{email}</a>.
+          </p>
+        ) : (
+          <p class="type-body">
+            For inquiries or submissions, reach out via the contact links below.
+          </p>
+        )}
+      </div>
+    </section>
+  </div>
+</Layout>
+
+<style>
+  .about-hero { padding: var(--size-layout-heading-spacing, 30px) var(--size-layout-gutter, 15px); border-bottom: 1px solid var(--color-black, #121212); }
+  .about-hero .type-intro { max-width: 640px; margin-top: var(--size-layout-element-spacing, 25px); }
+  .about-body { max-width: 680px; margin: 0 auto; padding: var(--size-layout-section-spacing, 40px) var(--size-layout-gutter, 15px); }
+  .about-block { margin-bottom: var(--size-layout-section-spacing, 40px); }
+  .about-block .type-subheading { margin-bottom: var(--size-layout-element-spacing, 25px); }
+  .about-block .type-body { line-height: 1.8; }
+  .about-block a { color: var(--color-accent, #e91e63); text-decoration: underline; text-underline-offset: 3px; }
+  .about-block a:hover { background: var(--color-accent, #e91e63); color: #fff; }
+</style>

--- a/www/src/pages/about.astro
+++ b/www/src/pages/about.astro
@@ -2,16 +2,27 @@
 import Layout from '../layouts/Layout.astro';
 import { cms } from '../lib/cms';
 
-let tagline = 'This is a House Gallery serves as a project and exhibition place for the DIY Bay Area art scene.';
-let contact: Record<string, unknown> = {};
+let tagline = 'This is a House Gallery serves as a project and exhibition space for the DIY Bay Area art scene.';
+let email = '';
+let instagram = '';
+let instagramUrl = '';
 try {
   const settings = await cms.siteSettings();
   if (settings.tagline) tagline = settings.tagline;
-  contact = settings.contact ?? {};
+  const contact = (settings.contact ?? {}) as Record<string, unknown>;
+  if (typeof contact.email === 'string' && contact.email) email = contact.email;
+  const socials = (settings.socials ?? []) as Record<string, unknown>[];
+  const ig = socials.find((s) => String(s.label ?? s.platform ?? '').toLowerCase().includes('instagram'))
+    ?? socials.find((s) => String(s.url ?? '').toLowerCase().includes('instagram'));
+  if (ig) {
+    instagram = String(ig.label ?? ig.handle ?? '@thisisahousegallery');
+    instagramUrl = String(ig.url ?? '');
+  }
 } catch {
   /* CMS unreachable — use defaults */
 }
-const email = typeof contact.email === 'string' ? contact.email : '';
+if (!instagram) instagram = '@thisisahousegallery';
+if (!instagramUrl) instagramUrl = 'https://instagram.com/thisisahousegallery';
 ---
 
 <Layout title="About — This is a House Gallery" bodyClass="about-page">
@@ -21,53 +32,79 @@ const email = typeof contact.email === 'string' ? contact.email : '';
       <p class="type-intro">{tagline}</p>
     </header>
 
-    <section class="about-body">
-      <div class="about-block">
-        <h2 class="type-subheading">The House</h2>
-        <p class="type-body">
-          This is a House Gallery is a project and exhibition space run out of a
-          house in the East Bay. We make room for the DIY Bay Area art scene —
-          the artists, objects, and communities that don’t always fit the white
-          cube — turning the domestic into a place to show, gather, and argue
-          about what art is for.
-        </p>
+    <div class="about-layout">
+      <div class="about-main">
+        <section class="about-block">
+          <h2 class="type-subheading">The House</h2>
+          <p class="type-body">
+            This is a House Gallery is a project and exhibition space run out of
+            a house in the East Bay, making room for the DIY Bay Area art scene —
+            the artists, objects, and communities that make this city what it is.
+          </p>
+        </section>
+
+        <section class="about-block">
+          <h2 class="type-subheading">Program</h2>
+          <p class="type-body">
+            Shows happen when they happen. When an artist brings work and a
+            conversation is worth starting, we make room for it. Openings are
+            free and open — come through, look close, say hello. See the{" "}
+            <a href="/schedule/">schedule</a> for what’s on, and browse past
+            shows under <a href="/exhibitions/">exhibitions</a>.
+          </p>
+        </section>
       </div>
 
-      <div class="about-block">
-        <h2 class="type-subheading">Program</h2>
-        <p class="type-body">
-          Exhibitions change month to month, each one an installation in the
-          space and a conversation with the people who made it. Openings are
-          free and open — come through, look close, say hello. See the{" "}
-          <a href="/schedule/">schedule</a> for what’s on, and browse past shows
-          under <a href="/exhibitions/">exhibitions</a>.
-        </p>
-      </div>
-
-      <div class="about-block">
-        <h2 class="type-subheading">Get in Touch</h2>
-        {email ? (
-          <p class="type-body">
-            For inquiries, submissions, or just to say hi, write to{" "}
-            <a class="email-link" href={`mailto:${email}`}>{email}</a>.
-          </p>
-        ) : (
-          <p class="type-body">
-            For inquiries or submissions, reach out via the contact links below.
-          </p>
-        )}
-      </div>
-    </section>
+      <aside class="about-aside">
+        <section class="about-block about-contact">
+          <h2 class="type-subheading">Get in Touch</h2>
+          <div class="about-contact__card">
+            <img src="/house-logo.png" alt="This is a House Gallery" class="about-contact__img" />
+            {email && (
+              <p class="about-contact__line">
+                <a class="email-link" href={`mailto:${email}`}>{email}</a>
+              </p>
+            )}
+            <a class="about-contact__line" href={instagramUrl} target="_blank" rel="noopener">
+              {instagram}
+            </a>
+          </div>
+        </section>
+      </aside>
+    </div>
   </div>
 </Layout>
 
 <style>
   .about-hero { padding: var(--size-layout-heading-spacing, 30px) var(--size-layout-gutter, 15px); border-bottom: 1px solid var(--color-black, #121212); }
   .about-hero .type-intro { max-width: 640px; margin-top: var(--size-layout-element-spacing, 25px); }
-  .about-body { max-width: 680px; margin: 0 auto; padding: var(--size-layout-section-spacing, 40px) var(--size-layout-gutter, 15px); }
-  .about-block { margin-bottom: var(--size-layout-section-spacing, 40px); }
+
+  /* Align the layout's left edge with the header/title gutter so the body
+     text lines up with the intro instead of being centered in its own column. */
+  .about-layout {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--size-layout-section-spacing, 48px);
+    padding: var(--size-layout-section-spacing, 48px) var(--size-layout-gutter, 15px);
+  }
+  @media (min-width: 900px) {
+    .about-layout { grid-template-columns: minmax(0, 1fr) 300px; align-items: start; column-gap: var(--size-layout-section-spacing, 48px); }
+  }
+
+  .about-main { max-width: 640px; }
+  .about-block { margin-bottom: var(--size-layout-section-spacing, 48px); }
+  .about-block:last-child { margin-bottom: 0; }
   .about-block .type-subheading { margin-bottom: var(--size-layout-element-spacing, 25px); }
   .about-block .type-body { line-height: 1.8; }
   .about-block a { color: var(--color-accent, #e91e63); text-decoration: underline; text-underline-offset: 3px; }
   .about-block a:hover { background: var(--color-accent, #e91e63); color: #fff; }
+
+  .about-aside { border-left: 1px solid var(--color-black, #121212); padding-left: var(--size-layout-section-spacing, 48px); }
+  @media (min-width: 900px) { .about-aside { position: sticky; top: 40px; } }
+  @media (max-width: 899px) { .about-aside { border-left: none; border-top: 1px solid var(--color-black, #121212); padding-left: 0; padding-top: var(--size-layout-section-spacing, 48px); } }
+
+  .about-contact__card { display: flex; flex-direction: column; gap: 1rem; }
+  .about-contact__img { width: 100%; max-width: 240px; border: 1px solid var(--color-black, #121212); }
+  .about-contact__line { font-size: var(--font-size-body, 16px); color: var(--color-accent, #e91e63); text-decoration: underline; text-underline-offset: 3px; }
+  .about-contact__line:hover { background: var(--color-accent, #e91e63); color: #fff; }
 </style>

--- a/www/src/pages/about.astro
+++ b/www/src/pages/about.astro
@@ -1,11 +1,14 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import { cms } from '../lib/cms';
+import { cms, bestImageUrl } from '../lib/cms';
 
 let tagline = 'This is a House Gallery serves as a project and exhibition space for the DIY Bay Area art scene.';
 let email = '';
 let instagram = '';
 let instagramUrl = '';
+// House/space photo: a real installation shot of the gallery room (CMS image
+// 1253) as a placeholder until a dedicated photo of the house is available.
+let houseImage = '';
 try {
   const settings = await cms.siteSettings();
   if (settings.tagline) tagline = settings.tagline;
@@ -18,6 +21,8 @@ try {
     instagram = String(ig.label ?? ig.handle ?? '@thisisahousegallery');
     instagramUrl = String(ig.url ?? '');
   }
+  const house = await cms.image(1253).catch(() => null);
+  if (house) houseImage = bestImageUrl(house, { max: 1200 }) ?? house.file_url ?? '';
 } catch {
   /* CMS unreachable — use defaults */
 }
@@ -59,7 +64,9 @@ if (!instagramUrl) instagramUrl = 'https://instagram.com/thisisahousegallery';
         <section class="about-block about-contact">
           <h2 class="type-subheading">Get in Touch</h2>
           <div class="about-contact__card">
-            <img src="/house-logo.png" alt="This is a House Gallery" class="about-contact__img" />
+            {houseImage && (
+              <img src={houseImage} alt="The gallery space" class="about-contact__img" loading="lazy" />
+            )}
             {email && (
               <p class="about-contact__line">
                 <a class="email-link" href={`mailto:${email}`}>{email}</a>

--- a/www/src/pages/about.astro
+++ b/www/src/pages/about.astro
@@ -68,14 +68,14 @@ if (!instagramUrl) instagramUrl = 'https://instagram.com/thisisahousegallery';
               <img src={houseImage} alt="The gallery space" class="about-contact__img" loading="lazy" />
             )}
             {email && (
-              <p class="social-media-link__item">
-                <span class="social-media-link__icon" aria-hidden="true">✉</span>
-                <a class="social-media-link__text" href={`mailto:${email}`}>{email}</a>
+              <p class="about-contact__item">
+                <span aria-hidden="true">✉</span>
+                <a href={`mailto:${email}`}>{email}</a>
               </p>
             )}
-            <p class="social-media-link__item social-media-link__item--instagram">
-              <span class="social-media-link__icon" aria-hidden="true">◎</span>
-              <a class="social-media-link__text" href={instagramUrl} target="_blank" rel="noopener">
+            <p class="about-contact__item">
+              <span aria-hidden="true">◎</span>
+              <a href={instagramUrl} target="_blank" rel="noopener">
                 {instagram}
               </a>
             </p>
@@ -107,14 +107,19 @@ if (!instagramUrl) instagramUrl = 'https://instagram.com/thisisahousegallery';
   .about-block:last-child { margin-bottom: 0; }
   .about-block .type-subheading { margin-bottom: var(--size-layout-element-spacing, 25px); }
   .about-block .type-body { line-height: 1.8; }
-  /* Body links follow the site's standard black + underline convention. */
-  .about-block .type-body a {
+  /* Inline body links: reuse the design system's standard link treatment
+     (see .event-artist-name a) — black text, underline fades in on hover. */
+  .about-block .type-body a,
+  .about-contact__item a {
     color: var(--color-black, #121212);
-    text-decoration: underline;
-    text-underline-offset: 3px;
-    font-weight: var(--font-weight-normal, 400);
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: border-color 0.2s ease;
   }
-  .about-block .type-body a:hover { background: var(--color-hover-background, #efefef); }
+  .about-block .type-body a:hover,
+  .about-contact__item a:hover {
+    border-bottom-color: var(--color-black, #121212);
+  }
 
   .about-aside { border-left: 1px solid var(--color-black, #121212); padding-left: var(--size-layout-section-spacing, 48px); }
   @media (min-width: 900px) { .about-aside { position: sticky; top: 40px; } }
@@ -124,8 +129,13 @@ if (!instagramUrl) instagramUrl = 'https://instagram.com/thisisahousegallery';
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.25rem;
+    gap: var(--size-layout-element-spacing, 25px);
   }
-  .about-contact__card .social-media-link__item { margin: 0; padding: 0.4rem 0; }
-  .about-contact__img { width: 100%; max-width: 260px; border: 1px solid var(--color-black, #121212); margin-bottom: 0.75rem; }
+  .about-contact__item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0;
+  }
+  .about-contact__img { width: 100%; max-width: 260px; border: 1px solid var(--color-black, #121212); margin-bottom: 0.25rem; }
 </style>

--- a/www/src/pages/exhibitions/index.astro
+++ b/www/src/pages/exhibitions/index.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../../layouts/Layout.astro';
+import PageHeader from '../../components/PageHeader.astro';
 import { cms, bestImageUrl, filteredGalleryImages } from '../../lib/cms';
 
 // Fetch details (they carry the photo galleries; the list endpoint does not).
@@ -17,11 +18,9 @@ function formatDate(iso: string | null): string {
 
 <Layout title="Exhibitions — This is a House Gallery" bodyClass="exhibitions-index">
   <div class="body">
-    <div class="exhibition-page-header">
-      <h1 class="title type-title">Exhibitions</h1>
-    </div>
+      <PageHeader title="Exhibitions" />
 
-    <div class="exhibitions-listing">
+      <div class="exhibitions-listing">
       {details.map((ex) => {
         const gallery = filteredGalleryImages(ex);
         const imgUrl = bestImageUrl(ex.listing_image, { max: 400 }) ??

--- a/www/src/pages/exhibitions/index.astro
+++ b/www/src/pages/exhibitions/index.astro
@@ -45,7 +45,7 @@ function formatDate(iso: string | null): string {
               <div class="exhibition-feature-gallery" data-gallery-id={ex.title.toLowerCase().replace(/\s+/g, '-')}>
                 <div class="gallery-container gallery-columns-container masonry">
                   <div class="gallery-images">
-                    {gallery.slice(0, 12).map((img, i) => (
+                    {gallery.map((img, i) => (
                       <button
                         class="gallery-lightbox-item"
                         data-media-type="image"

--- a/www/src/pages/exhibitions/index.astro
+++ b/www/src/pages/exhibitions/index.astro
@@ -75,3 +75,12 @@ function formatDate(iso: string | null): string {
     </div>
   </div>
 </Layout>
+
+<style>
+  /* The shared PageHeader now owns the title header (padding + bottom rule), so
+     the legacy exhibitions-index body margin is redundant — it added a large
+     heading-sized margin that misaligned this page's header vs. the others. */
+  .exhibitions-index .body {
+    margin: 0;
+  }
+</style>

--- a/www/src/pages/schedule.astro
+++ b/www/src/pages/schedule.astro
@@ -1,0 +1,99 @@
+---
+// Schedule — exhibition-driven program page.
+// The gallery's program IS its exhibitions (13 shows, 2023–2026). "Schedule"
+// answers "when do things happen" as a chronological timeline rather than a
+// card grid. Shows are grouped into Upcoming / Happening Now / Past (the first
+// two appear automatically once future-dated shows exist). Each show carries
+// its opening event underneath where one is mapped.
+import Layout from '../layouts/Layout.astro';
+import ProgramRow from '../components/ProgramRow.astro';
+import { cms, type EventItem, type Exhibition } from '../lib/cms';
+
+const exhibitions: Exhibition[] = await cms.exhibitions().catch(() => []);
+const events: EventItem[] = await cms.events().catch(() => []);
+
+const today = new Date();
+today.setHours(0, 0, 0, 0);
+
+function endDate(ex: Exhibition): Date {
+  return ex.end_date ? new Date(ex.end_date) : (ex.start_date ? new Date(ex.start_date) : today);
+}
+const byDesc = (a: Exhibition, b: Exhibition) => +(endDate(b) ?? 0) - +(endDate(a) ?? 0);
+
+const upcoming = exhibitions.filter((x) => x.start_date && new Date(x.start_date) > today).sort(byDesc);
+const current = exhibitions
+  .filter((x) => {
+    const s = x.start_date ? new Date(x.start_date) : null;
+    const e = endDate(x);
+    return s && s <= today && e >= today;
+  })
+  .sort(byDesc);
+const past = exhibitions.filter((x) => !upcoming.includes(x) && !current.includes(x)).sort(byDesc);
+
+// Events keyed to a show by title (normalized), since only one is FK-linked.
+function norm(s: string) {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+const eventsByShow = new Map<string, EventItem[]>();
+for (const ev of events) {
+  const relTitle = ev.related_exhibition?.title;
+  if (relTitle) {
+    const k = norm(relTitle);
+    eventsByShow.set(k, [...(eventsByShow.get(k) ?? []), ev]);
+  }
+}
+---
+
+<Layout title="Schedule — This is a House Gallery" bodyClass="schedule-page">
+  <div class="body">
+    <header class="schedule-header">
+      <h1 class="title type-title">Schedule</h1>
+      <p class="type-intro">Our program of exhibitions and openings.</p>
+    </header>
+
+    {current.length > 0 && (
+      <section class="program-section program-current">
+        <h2 class="section-heading program-heading"><span class="section-icon">🔴</span> Happening Now</h2>
+        <div class="program-list">
+          {current.map((ex) => <ProgramRow ex={ex} eventsByShow={eventsByShow} />)}
+        </div>
+      </section>
+    )}
+
+    {upcoming.length > 0 && (
+      <section class="program-section program-upcoming">
+        <h2 class="section-heading program-heading">Coming Up</h2>
+        <div class="program-list">
+          {upcoming.map((ex) => <ProgramRow ex={ex} eventsByShow={eventsByShow} />)}
+        </div>
+      </section>
+    )}
+
+    <section class="program-section program-past">
+      <h2 class="section-heading program-heading">
+        {current.length === 0 && upcoming.length === 0 ? 'Program' : 'Past Program'}
+      </h2>
+      <div class="program-list">
+        {past.map((ex) => <ProgramRow ex={ex} eventsByShow={eventsByShow} />)}
+      </div>
+    </section>
+
+    {exhibitions.length === 0 && (
+      <div class="empty-state">
+        <div class="empty-state-content">
+          <span class="empty-state-icon">📅</span>
+          <h3>No Shows Scheduled</h3>
+          <p>Check back soon for upcoming exhibitions and events.</p>
+        </div>
+      </div>
+    )}
+  </div>
+</Layout>
+
+<style>
+  .schedule-header { padding-bottom: var(--size-layout-element-spacing, 25px); }
+  .schedule-header .type-intro { margin-top: var(--size-layout-element-spacing, 25px); max-width: 600px; }
+  .program-section { padding: 0 var(--size-layout-gutter, 15px); margin-bottom: var(--size-layout-section-spacing, 40px); }
+  .program-heading { border-bottom: 1px solid var(--color-black, #121212); padding-bottom: 0.5rem; }
+  .program-list { display: flex; flex-direction: column; }
+</style>

--- a/www/src/pages/schedule.astro
+++ b/www/src/pages/schedule.astro
@@ -2,14 +2,20 @@
 // Schedule — exhibition-driven program page.
 // The gallery's program IS its exhibitions (13 shows, 2023–2026). "Schedule"
 // answers "when do things happen" as a chronological timeline rather than a
-// card grid. Shows are grouped into Upcoming / Happening Now / Past (the first
-// two appear automatically once future-dated shows exist). Each show carries
-// its opening event underneath where one is mapped.
+// card grid. It's split into an Upcoming section and a Past Program, so the
+// past/upcoming distinction is always legible. Each show gets an opening badge
+// on its start date (every show is an opening), and genuinely non-opening
+// programming (talks, workshops, closings) is folded in from the events table.
 import Layout from '../layouts/Layout.astro';
 import ProgramRow from '../components/ProgramRow.astro';
 import { cms, type EventItem, type Exhibition } from '../lib/cms';
 
 const exhibitions: Exhibition[] = await cms.exhibitions().catch(() => []);
+// Photos (opening/installation/showcard) only ship on the detail endpoint, so
+// fetch details in parallel for every show — that's what the thumbnails need.
+const details: Exhibition[] = await Promise.all(
+  exhibitions.map((ex) => cms.exhibition(ex.slug).catch(() => ex))
+);
 const events: EventItem[] = await cms.events().catch(() => []);
 
 const today = new Date();
@@ -20,27 +26,33 @@ function endDate(ex: Exhibition): Date {
 }
 const byDesc = (a: Exhibition, b: Exhibition) => +(endDate(b) ?? 0) - +(endDate(a) ?? 0);
 
-const upcoming = exhibitions.filter((x) => x.start_date && new Date(x.start_date) > today).sort(byDesc);
-const current = exhibitions
+const upcoming = details.filter((x) => x.start_date && new Date(x.start_date) > today).sort(byDesc);
+const current = details
   .filter((x) => {
     const s = x.start_date ? new Date(x.start_date) : null;
     const e = endDate(x);
     return s && s <= today && e >= today;
   })
   .sort(byDesc);
-const past = exhibitions.filter((x) => !upcoming.includes(x) && !current.includes(x)).sort(byDesc);
+const past = details.filter((x) => !upcoming.includes(x) && !current.includes(x)).sort(byDesc);
 
-// Events keyed to a show by title (normalized), since only one is FK-linked.
+// Events keyed to a show by title (normalized). Only NON-opening events get
+// their own badge here — the opening badge is derived per-show from start_date.
 function norm(s: string) {
   return s.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
 }
 const eventsByShow = new Map<string, EventItem[]>();
 for (const ev of events) {
-  const relTitle = ev.related_exhibition?.title;
-  if (relTitle) {
-    const k = norm(relTitle);
-    eventsByShow.set(k, [...(eventsByShow.get(k) ?? []), ev]);
-  }
+  if (ev.event_type === 'exhibition_opening') continue; // surfaces as the show's opening badge
+  const relTitle = ev.related_exhibition?.title || ev.title;
+  const k = norm(relTitle);
+  eventsByShow.set(k, [...(eventsByShow.get(k) ?? []), ev]);
+}
+function nonOpeningFor(ex: Exhibition): EventItem[] {
+  // Match by exhibition title, else by a show title contained within the event.
+  const exact = eventsByShow.get(norm(ex.title)) ?? [];
+  if (exact.length) return exact;
+  return events.filter((ev) => norm(ev.title).includes(norm(ex.title)));
 }
 ---
 
@@ -55,26 +67,28 @@ for (const ev of events) {
       <section class="program-section program-current">
         <h2 class="section-heading program-heading"><span class="section-icon">🔴</span> Happening Now</h2>
         <div class="program-list">
-          {current.map((ex) => <ProgramRow ex={ex} eventsByShow={eventsByShow} />)}
+          {current.map((ex) => <ProgramRow ex={ex} nonOpeningEvents={nonOpeningFor(ex)} />)}
         </div>
       </section>
     )}
 
-    {upcoming.length > 0 && (
-      <section class="program-section program-upcoming">
-        <h2 class="section-heading program-heading">Coming Up</h2>
+    <section class="program-section program-upcoming">
+      <h2 class="section-heading program-heading">Upcoming</h2>
+      {upcoming.length > 0 ? (
         <div class="program-list">
-          {upcoming.map((ex) => <ProgramRow ex={ex} eventsByShow={eventsByShow} />)}
+          {upcoming.map((ex) => <ProgramRow ex={ex} nonOpeningEvents={nonOpeningFor(ex)} />)}
         </div>
-      </section>
-    )}
+      ) : (
+        <div class="program-empty">
+          <p>No upcoming shows scheduled yet — check back soon.</p>
+        </div>
+      )}
+    </section>
 
     <section class="program-section program-past">
-      <h2 class="section-heading program-heading">
-        {current.length === 0 && upcoming.length === 0 ? 'Program' : 'Past Program'}
-      </h2>
+      <h2 class="section-heading program-heading">Past Program</h2>
       <div class="program-list">
-        {past.map((ex) => <ProgramRow ex={ex} eventsByShow={eventsByShow} />)}
+        {past.map((ex) => <ProgramRow ex={ex} nonOpeningEvents={nonOpeningFor(ex)} />)}
       </div>
     </section>
 
@@ -93,7 +107,8 @@ for (const ev of events) {
 <style>
   .schedule-header { padding-bottom: var(--size-layout-element-spacing, 25px); }
   .schedule-header .type-intro { margin-top: var(--size-layout-element-spacing, 25px); max-width: 600px; }
-  .program-section { padding: 0 var(--size-layout-gutter, 15px); margin-bottom: var(--size-layout-section-spacing, 40px); }
-  .program-heading { border-bottom: 1px solid var(--color-black, #121212); padding-bottom: 0.5rem; }
-  .program-list { display: flex; flex-direction: column; }
+  .program-section { margin-bottom: var(--size-layout-section-spacing, 48px); }
+  .program-heading { border-bottom: 1px solid var(--color-black, #121212); padding: var(--size-layout-element-spacing, 25px) var(--size-layout-gutter, 15px) 0.5rem; }
+  .program-list { padding: 0 var(--size-layout-gutter, 15px); display: flex; flex-direction: column; }
+  .program-empty { padding: var(--size-layout-element-spacing, 25px) var(--size-layout-gutter, 15px); color: var(--color-text-secondary, #666); font-style: italic; }
 </style>

--- a/www/src/pages/schedule.astro
+++ b/www/src/pages/schedule.astro
@@ -38,12 +38,13 @@ const past = details.filter((x) => !upcoming.includes(x) && !current.includes(x)
 
 // Events keyed to a show by title (normalized). Only NON-opening events get
 // their own badge here — the opening badge is derived per-show from start_date.
+// Filter calls on the raw events list separately so non-opening is the invariant.
 function norm(s: string) {
   return s.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
 }
+const nonOpeningEvents = events.filter((ev) => ev.event_type !== 'exhibition_opening');
 const eventsByShow = new Map<string, EventItem[]>();
-for (const ev of events) {
-  if (ev.event_type === 'exhibition_opening') continue; // surfaces as the show's opening badge
+for (const ev of nonOpeningEvents) {
   const relTitle = ev.related_exhibition?.title || ev.title;
   const k = norm(relTitle);
   eventsByShow.set(k, [...(eventsByShow.get(k) ?? []), ev]);
@@ -52,7 +53,7 @@ function nonOpeningFor(ex: Exhibition): EventItem[] {
   // Match by exhibition title, else by a show title contained within the event.
   const exact = eventsByShow.get(norm(ex.title)) ?? [];
   if (exact.length) return exact;
-  return events.filter((ev) => norm(ev.title).includes(norm(ex.title)));
+  return nonOpeningEvents.filter((ev) => norm(ev.title).includes(norm(ex.title)));
 }
 ---
 
@@ -86,7 +87,7 @@ function nonOpeningFor(ex: Exhibition): EventItem[] {
     </section>
 
     <section class="program-section program-past">
-      <h2 class="section-heading program-heading">Past Program</h2>
+      <h2 class="section-heading program-heading">Past</h2>
       <div class="program-list">
         {past.map((ex) => <ProgramRow ex={ex} nonOpeningEvents={nonOpeningFor(ex)} />)}
       </div>
@@ -105,10 +106,11 @@ function nonOpeningFor(ex: Exhibition): EventItem[] {
 </Layout>
 
 <style>
-  .schedule-header { padding-bottom: var(--size-layout-element-spacing, 25px); }
+  .schedule-header { padding-bottom: var(--size-layout-section-spacing, 40px); }
   .schedule-header .type-intro { margin-top: var(--size-layout-element-spacing, 25px); max-width: 600px; }
   .program-section { margin-bottom: var(--size-layout-section-spacing, 48px); }
-  .program-heading { border-bottom: 1px solid var(--color-black, #121212); padding: var(--size-layout-element-spacing, 25px) var(--size-layout-gutter, 15px) 0.5rem; }
+  .program-upcoming { margin-top: var(--size-layout-section-spacing, 48px); }
+  .program-heading { border-bottom: 1px solid var(--color-black, #121212); padding: 0 var(--size-layout-gutter, 15px) 0.5rem; }
   .program-list { padding: 0 var(--size-layout-gutter, 15px); display: flex; flex-direction: column; }
   .program-empty { padding: var(--size-layout-element-spacing, 25px) var(--size-layout-gutter, 15px); color: var(--color-text-secondary, #666); font-style: italic; }
 </style>

--- a/www/src/pages/schedule.astro
+++ b/www/src/pages/schedule.astro
@@ -8,6 +8,7 @@
 // programming (talks, workshops, closings) is folded in from the events table.
 import Layout from '../layouts/Layout.astro';
 import ProgramRow from '../components/ProgramRow.astro';
+import PageHeader from '../components/PageHeader.astro';
 import { cms, type EventItem, type Exhibition } from '../lib/cms';
 
 const exhibitions: Exhibition[] = await cms.exhibitions().catch(() => []);
@@ -59,10 +60,7 @@ function nonOpeningFor(ex: Exhibition): EventItem[] {
 
 <Layout title="Schedule — This is a House Gallery" bodyClass="schedule-page">
   <div class="body">
-    <header class="schedule-header">
-      <h1 class="title type-title">Schedule</h1>
-      <p class="type-intro">Our program of exhibitions and openings.</p>
-    </header>
+    <PageHeader title="Schedule" />
 
     {current.length > 0 && (
       <section class="program-section program-current">
@@ -106,11 +104,9 @@ function nonOpeningFor(ex: Exhibition): EventItem[] {
 </Layout>
 
 <style>
-  .schedule-header { padding-bottom: var(--size-layout-section-spacing, 40px); }
-  .schedule-header .type-intro { margin-top: var(--size-layout-element-spacing, 25px); max-width: 600px; }
-  .program-section { margin-bottom: var(--size-layout-section-spacing, 48px); }
+  .program-section { padding: 0 var(--size-layout-gutter, 15px); margin-bottom: var(--size-layout-section-spacing, 48px); }
   .program-upcoming { margin-top: var(--size-layout-section-spacing, 48px); }
-  .program-heading { border-bottom: 1px solid var(--color-black, #121212); padding: 0 var(--size-layout-gutter, 15px) 0.5rem; }
-  .program-list { padding: 0 var(--size-layout-gutter, 15px); display: flex; flex-direction: column; }
-  .program-empty { padding: var(--size-layout-element-spacing, 25px) var(--size-layout-gutter, 15px); color: var(--color-text-secondary, #666); font-style: italic; }
+  .program-heading { border-bottom: 1px solid var(--color-black, #121212); padding: 0 0 0.5rem; }
+  .program-list { display: flex; flex-direction: column; }
+  .program-empty { padding: var(--size-layout-element-spacing, 25px) 0; color: var(--color-text-secondary, #666); font-style: italic; }
 </style>


### PR DESCRIPTION
## What
Adds the two remaining public routes to reach feature parity with the live site — **redesigned around real data** (the gallery's program IS its 13 exhibitions, not the 3 sparse events). Depends on **PR-A1** (#24, /v1/events + Event model).

## Design pivot (from review)
The first draft rendered an events card grid like the source, but the source only has **3 all-past events** — so it looked empty and confusing (a sticky, old `featured_on_schedule` flag made it worse). Per review, **/schedule/ is now exhibition-driven**: a chronological program of the 13 shows, with each show's opening event folded underneath where one exists.

## Includes
- `pages/schedule.astro` — chronological program (Upcoming / Happening Now / Past; the first two appear automatically once future-dated shows exist). Each show: date range, title, artists, thumbnail, opening-event badge (type + date) where mapped.
- `components/ProgramRow.astro` — a single program row
- `pages/about.astro` — real copy (prod's was a placeholder): The House / Program / Get in Touch
- `lib/cms.ts` — `EventItem` type + `cms.events()`

## Verified
17 pages build; /schedule/ lists all 13 shows newest-first (After Market → This is a Living Room) with the Food At Home opening event nested; /about/ renders the new copy. Visually confirmed.